### PR TITLE
Make it work reliably

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-gcc -Wall -O0 -g3 -I./include src/cuckoo_filter.c tests/cuckootest.c -o test
-gcc -Wall -O0 -g3 -I./include src/cuckoo_filter.c tests/cuckootest2.c -o test2
+gcc -Wall -std=c99 -fsanitize=address -O2 -g3 -I./include src/cuckoo_filter.c tests/cuckootest.c -o test
+gcc -Wall -std=c99 -fsanitize=address -O2 -g3 -I./include src/cuckoo_filter.c tests/cuckootest2.c -o test2
 

--- a/src/cuckoo_filter.c
+++ b/src/cuckoo_filter.c
@@ -61,7 +61,6 @@ add_fingerprint_to_bucket (
   uint32_t              fp,
   uint32_t              h
 ) {
-  fp &= filter->mask;
   for (size_t ii = 0; ii < filter->nests_per_bucket; ++ii) {
     cuckoo_nest_t *nest =
       &filter->bucket[(h * filter->nests_per_bucket) + ii];
@@ -83,7 +82,6 @@ remove_fingerprint_from_bucket (
   uint32_t              fp,
   uint32_t              h
 ) {
-  fp &= filter->mask;
   for (size_t ii = 0; ii < filter->nests_per_bucket; ++ii) {
     cuckoo_nest_t *nest =
       &filter->bucket[(h * filter->nests_per_bucket) + ii];
@@ -119,7 +117,7 @@ cuckoo_filter_move (
     return CUCKOO_FILTER_OK;
   }
 
-printf("depth = %u\n", depth);
+//printf("depth = %u\n", depth);
   if (filter->max_kick_attempts == depth) {
     return CUCKOO_FILTER_FULL;
   }
@@ -200,6 +198,7 @@ cuckoo_filter_lookup (
 ) {
   uint32_t fingerprint = hash(key, key_length_in_bytes, filter->bucket_count,
     1000, filter->seed);
+  fingerprint &= filter->mask; fingerprint += !fingerprint;
   uint32_t h1 = hash(key, key_length_in_bytes, filter->bucket_count, 0,
     filter->seed);
   uint32_t h2 = ((h1 ^ hash(&fingerprint, sizeof(fingerprint),
@@ -210,7 +209,6 @@ cuckoo_filter_lookup (
   result->item.h1 = 0;
   result->item.h2 = 0;
 
-  fingerprint &= filter->mask;
   for (size_t ii = 0; ii < filter->nests_per_bucket; ++ii) {
     cuckoo_nest_t *n1 =
       &filter->bucket[(h1  * filter->nests_per_bucket) + ii];

--- a/src/cuckoo_filter.c
+++ b/src/cuckoo_filter.c
@@ -150,15 +150,14 @@ cuckoo_filter_new (
     bucket_count <<= 1;
   }
 
+  /* FIXME: Should check for integer overflows here */
   size_t allocation_in_bytes = (sizeof(cuckoo_filter_t)
     + (bucket_count * CUCKOO_NESTS_PER_BUCKET * sizeof(cuckoo_nest_t)));
 
-  if (0 != posix_memalign((void **) &new_filter, sizeof(uint64_t),
-    allocation_in_bytes)) {
+  new_filter = calloc(allocation_in_bytes, 1);
+  if (!new_filter) {
     return CUCKOO_FILTER_ALLOCATION_FAILED;
   }
-
-  memset(new_filter, 0, allocation_in_bytes);
 
   new_filter->last_victim = NULL;
   memset(&new_filter->victim, 0, sizeof(new_filter)->victim);

--- a/tests/cuckootest.c
+++ b/tests/cuckootest.c
@@ -32,6 +32,21 @@ main (int argc, char ** argv) {
   if (CUCKOO_FILTER_OK == rc) {
     printf("%s/%d: %d\n", __func__, __LINE__, rc);
   }
+
+  int i;
+  for (i = 0; i < 460000; i++) {
+    rc = cuckoo_filter_add(filter, &i, sizeof(i));
+    if (CUCKOO_FILTER_OK != rc) {
+      printf("%s/%d: %d\n", __func__, __LINE__, rc);
+    }
+  }
+
+  for (i = 0; i < 460000; i++) {
+    rc = cuckoo_filter_contains(filter, &i, sizeof(i));
+    if (CUCKOO_FILTER_OK != rc) {
+      printf("%s/%d: %d %d\n", __func__, __LINE__, rc, i);
+    }
+  }
   
   rc = cuckoo_filter_free(&filter);
   if (CUCKOO_FILTER_OK != rc) {


### PR DESCRIPTION
While @avgerin0s' fork fixed the worst bugs of the original, it didn't apply the fingerprint mask consistently and didn't avoid the magic fingerprint value 0 used to mark empty entries, and was failing more extensive tests than those included.

While at it, I also added usage of ASan for tests, a test at _requested_ 92% load factor (somehow even 94% often fails despite the filter is actually larger than requested, indicating there's something imperfect in the filter implementation), and switched away from misuse of `posix_memalign()` since suitability for a mere `uint64_t` is guaranteed by simple `malloc()` and `calloc()`.

The implementation is still far from optimal, and I don't recommend it for actual use, but this PR should make it another valid reference to consider.